### PR TITLE
Adding blog feed for php-schulung.de

### DIFF
--- a/feed_list
+++ b/feed_list
@@ -216,3 +216,4 @@ http://feeds.feedburner.com/TechnicalIssuesOnPhp
 http://jmather.com/feed/
 http://blog.mayflower.de/tags/symfony/feed
 http://jolicode.com/feeds/blog/tag/php.atom
+http://www.php-schulung.de/blog/feed/


### PR DESCRIPTION
Adding blog feed for php-schulung.de to the Symfony bloggers feedlist.

Thank you for maintinging the list!
